### PR TITLE
Fixed Gettext parsing of function args

### DIFF
--- a/lib/Localizer/Style/Gettext.pm
+++ b/lib/Localizer/Style/Gettext.pm
@@ -69,7 +69,7 @@ sub _compile {
 
             my $code = q!$functions->{'! . $function_name . q!'}->(!;
             for my $arg (split(/,/, $4)) {
-                if (my $num = $arg =~ /%(.+)/) {
+                if (my ($num) = $arg =~ /%(\d+)/) {
                     $code .= '$_[' . $num . '], ';
                 }
                 else {

--- a/t/02_Gettext.t
+++ b/t/02_Gettext.t
@@ -11,6 +11,7 @@ subtest 'gettext style' => sub {
         dictionary => +{
             'Hello, World!'                  => 'Hallo, Welt!',
             'Double %dubbil(%1)'             => 'Doppelt %dubbil(%1)',
+            'Double %dubbil(%1) %dubbil(%2)' => 'Doppelt %dubbil(%1) %dubbil(%2)',
             'You have %*(%1,piece) of mail.' => 'Sie haben %*(%1,Poststueck,Poststuecken).',
             'Price: %#(%1)'                  => 'Preis: %#(%1)',
             '%1()'                           => '%1()',
@@ -35,6 +36,7 @@ subtest 'gettext style' => sub {
 
     is $de->maketext('Hello, World!'), 'Hallo, Welt!', 'simple case';
     is $de->maketext('Double %dubbil(%1)', 7), 'Doppelt 14';
+    is $de->maketext('Double %dubbil(%1) %dubbil(%2)', 7, 5), 'Doppelt 14 10';
     is $de->maketext('You have %*(%1,piece) of mail.', 1), 'Sie haben 1 Poststueck.';
     is $de->maketext('You have %*(%1,piece) of mail.', 10), 'Sie haben 10 Poststuecken.';
     is $de->maketext('Price: %#(%1)', 1000000), 'Preis: 1,000,000';


### PR DESCRIPTION
Hi, we started to use functions on our localized gettext style strings and discovered it was not working correctly when passing anything different than `%1` to a function. Once discovered it was a really easy fix.

I've also added a test to reproduce the problem which is now passing. Please let me know if you need any change to merge it and publish to CPAN.